### PR TITLE
Add ActivityContact segment tracking

### DIFF
--- a/CRM/Segmentation/ActivityContactCreateAPIWrapper.php
+++ b/CRM/Segmentation/ActivityContactCreateAPIWrapper.php
@@ -15,8 +15,10 @@ class CRM_Segmentation_ActivityContactCreateAPIWrapper implements API_Wrapper {
    * @inheritDoc
    */
   public function toApiOutput($apiRequest, $result) {
-    if (isset($result['id'])) {
-      CRM_Segmentation_Logic::addSegmentForActivityContact($result['values'][0]['activity_id'], $result['values'][0]['contact_id']);
+    if (isset($result['values'])) {
+      foreach ($result['values'] as $activity_contact) {
+        CRM_Segmentation_Logic::addSegmentForActivityContact($activity_contact['activity_id'], $activity_contact['contact_id']);
+      }
     }
     return $result;
   }

--- a/CRM/Segmentation/ActivityContactCreateAPIWrapper.php
+++ b/CRM/Segmentation/ActivityContactCreateAPIWrapper.php
@@ -1,0 +1,24 @@
+<?php
+
+class CRM_Segmentation_ActivityContactCreateAPIWrapper implements API_Wrapper {
+
+  /**
+   * @inheritDoc
+   */
+  public function fromApiInput($apiRequest) {
+    return $apiRequest;
+  }
+
+  /**
+   * Try to add segment if an ActivityContact was created
+   *
+   * @inheritDoc
+   */
+  public function toApiOutput($apiRequest, $result) {
+    if (isset($result['id'])) {
+      CRM_Segmentation_Logic::addSegmentToActivityContact($result['values'][0]['activity_id'], $result['values'][0]['contact_id']);
+    }
+    return $result;
+  }
+
+}

--- a/CRM/Segmentation/ActivityContactCreateAPIWrapper.php
+++ b/CRM/Segmentation/ActivityContactCreateAPIWrapper.php
@@ -16,7 +16,7 @@ class CRM_Segmentation_ActivityContactCreateAPIWrapper implements API_Wrapper {
    */
   public function toApiOutput($apiRequest, $result) {
     if (isset($result['id'])) {
-      CRM_Segmentation_Logic::addSegmentToActivityContact($result['values'][0]['activity_id'], $result['values'][0]['contact_id']);
+      CRM_Segmentation_Logic::addSegmentForActivityContact($result['values'][0]['activity_id'], $result['values'][0]['contact_id']);
     }
     return $result;
   }

--- a/CRM/Segmentation/ActivityContactStore.php
+++ b/CRM/Segmentation/ActivityContactStore.php
@@ -1,0 +1,35 @@
+<?php
+
+class CRM_Segmentation_ActivityContactStore {
+
+  private $_contacts = [];
+
+  public static function getInstance() {
+    static $instance = NULL;
+    if (NULL === $instance) {
+      $instance = new static();
+    }
+
+    return $instance;
+  }
+
+  /**
+   * @param array $contacts
+   */
+  public function setContacts(array $contacts) {
+    $this->_contacts = $contacts;
+  }
+
+  public function popContacts() {
+    $contacts = $this->_contacts;
+    $this->_contacts = [];
+    return $contacts;
+  }
+
+  protected function __construct() {
+  }
+
+  private function __wakeup() {
+  }
+
+}

--- a/CRM/Segmentation/Form/CreateActivity.php
+++ b/CRM/Segmentation/Form/CreateActivity.php
@@ -191,18 +191,7 @@ class CRM_Segmentation_Form_CreateActivity extends CRM_Core_Form {
                       AND civicrm_contact.is_deleted = 0)";
         CRM_Core_DAO::executeQuery($query);
 
-        // keep track of segments in activities assigned to contacts
-        // segment are consolidated when the campaign is started, so no need to
-        // handle that here
-        $query = "INSERT IGNORE INTO civicrm_activity_contact_segmentation (activity_contact_id, segment_id)
-                   (SELECT
-                      civicrm_activity_contact.id,
-                      civicrm_segmentation.segment_id
-                    FROM civicrm_segmentation
-                    INNER JOIN civicrm_activity_contact ON civicrm_segmentation.entity_id=civicrm_activity_contact.contact_id
-                    WHERE campaign_id = {$values['cid']}
-                      AND activity_id={$activity['id']})";
-        CRM_Core_DAO::executeQuery($query);
+        CRM_Segmentation_Logic::addSegmentForMassActivity($activity['id'], $values['cid']);
       }
       // create popup
       $activity_edit_url = CRM_Utils_System::url('civicrm/activity/add', "atype=1&action=update&reset=1&id={$activity['id']}");

--- a/CRM/Segmentation/Form/CreateActivity.php
+++ b/CRM/Segmentation/Form/CreateActivity.php
@@ -192,7 +192,8 @@ class CRM_Segmentation_Form_CreateActivity extends CRM_Core_Form {
         CRM_Core_DAO::executeQuery($query);
 
         // keep track of segments in activities assigned to contacts
-        // @TODO: order?
+        // segment are consolidated when the campaign is started, so no need to
+        // handle that here
         $query = "INSERT IGNORE INTO civicrm_activity_contact_segmentation (activity_contact_id, segment_id)
                    (SELECT
                       civicrm_activity_contact.id,

--- a/CRM/Segmentation/Form/CreateActivity.php
+++ b/CRM/Segmentation/Form/CreateActivity.php
@@ -190,6 +190,18 @@ class CRM_Segmentation_Form_CreateActivity extends CRM_Core_Form {
                     WHERE campaign_id = {$values['cid']}
                       AND civicrm_contact.is_deleted = 0)";
         CRM_Core_DAO::executeQuery($query);
+
+        // keep track of segments in activities assigned to contacts
+        // @TODO: order?
+        $query = "INSERT IGNORE INTO civicrm_activity_contact_segmentation (activity_contact_id, segment_id)
+                   (SELECT
+                      civicrm_activity_contact.id,
+                      civicrm_segmentation.segment_id
+                    FROM civicrm_segmentation
+                    INNER JOIN civicrm_activity_contact ON civicrm_segmentation.entity_id=civicrm_activity_contact.contact_id
+                    WHERE campaign_id = {$values['cid']}
+                      AND activity_id={$activity['id']})";
+        CRM_Core_DAO::executeQuery($query);
       }
       // create popup
       $activity_edit_url = CRM_Utils_System::url('civicrm/activity/add', "atype=1&action=update&reset=1&id={$activity['id']}");

--- a/CRM/Segmentation/Logic.php
+++ b/CRM/Segmentation/Logic.php
@@ -325,13 +325,35 @@ class CRM_Segmentation_Logic {
   }
 
   /**
-   * Add the segment to an existing ActivityContact. Skips if a segment is
+   * Add segments for a mass activity. Only use if campaign has a consolidated
+   * segment order (@see CRM_Segmentation_Logic::consolidateSegments())
+   *
+   * @param $activity_id int
+   * @param $campaign_id int
+   */
+  public static function addSegmentForMassActivity($activity_id, $campaign_id) {
+    $query = "INSERT IGNORE INTO civicrm_activity_contact_segmentation (activity_contact_id, segment_id)
+                   (SELECT
+                      civicrm_activity_contact.id,
+                      civicrm_segmentation.segment_id
+                    FROM civicrm_segmentation
+                    INNER JOIN civicrm_activity_contact ON civicrm_segmentation.entity_id=civicrm_activity_contact.contact_id
+                    WHERE activity_id = %0
+                      AND campaign_id = %1)";
+    CRM_Core_DAO::executeQuery($query, [
+      [$activity_id, 'Integer'],
+      [$campaign_id, 'Integer'],
+    ]);
+  }
+
+  /**
+   * Add segment to an existing ActivityContact. Skips if a segment is
    * already assigned or if activity hasn't been assigned to contact at all.
    *
    * @param $activity_id int
    * @param $contact_id int
    */
-  public static function addSegmentToActivityContact($activity_id, $contact_id) {
+  public static function addSegmentForActivityContact($activity_id, $contact_id) {
     $query = "INSERT IGNORE INTO civicrm_activity_contact_segmentation (activity_contact_id, segment_id)
                    (SELECT
                       civicrm_activity_contact.id,

--- a/CRM/Segmentation/Logic.php
+++ b/CRM/Segmentation/Logic.php
@@ -323,4 +323,29 @@ class CRM_Segmentation_Logic {
     }
     return $all_segments;
   }
+
+  /**
+   * Add the segment to an existing ActivityContact. Skips if a segment is
+   * already assigned or if activity hasn't been assigned to contact at all.
+   *
+   * @param $activity_id int
+   * @param $contact_id int
+   */
+  public static function addSegmentToActivityContact($activity_id, $contact_id) {
+    // @TODO: order?
+    $query = "INSERT IGNORE INTO civicrm_activity_contact_segmentation (activity_contact_id, segment_id)
+                   (SELECT
+                      civicrm_activity_contact.id,
+                      civicrm_segmentation.segment_id
+                    FROM civicrm_activity_contact
+                    INNER JOIN civicrm_activity ON civicrm_activity.id=civicrm_activity_contact.activity_id
+                    INNER JOIN civicrm_segmentation ON civicrm_segmentation.entity_id=civicrm_activity_contact.contact_id AND civicrm_segmentation.campaign_id=civicrm_activity.campaign_id
+                    WHERE civicrm_activity_contact.activity_id=%0 AND
+                      civicrm_activity_contact.contact_id=%1)";
+    CRM_Core_DAO::executeQuery($query, [
+      [$activity_id, 'Integer'],
+      [$contact_id, 'Integer'],
+    ]);
+  }
+
 }

--- a/CRM/Segmentation/Logic.php
+++ b/CRM/Segmentation/Logic.php
@@ -332,16 +332,20 @@ class CRM_Segmentation_Logic {
    * @param $contact_id int
    */
   public static function addSegmentToActivityContact($activity_id, $contact_id) {
-    // @TODO: order?
     $query = "INSERT IGNORE INTO civicrm_activity_contact_segmentation (activity_contact_id, segment_id)
                    (SELECT
                       civicrm_activity_contact.id,
                       civicrm_segmentation.segment_id
                     FROM civicrm_activity_contact
                     INNER JOIN civicrm_activity ON civicrm_activity.id=civicrm_activity_contact.activity_id
-                    INNER JOIN civicrm_segmentation ON civicrm_segmentation.entity_id=civicrm_activity_contact.contact_id AND civicrm_segmentation.campaign_id=civicrm_activity.campaign_id
-                    WHERE civicrm_activity_contact.activity_id=%0 AND
-                      civicrm_activity_contact.contact_id=%1)";
+                    INNER JOIN civicrm_segmentation ON civicrm_segmentation.entity_id=civicrm_activity_contact.contact_id
+                                                   AND civicrm_segmentation.campaign_id=civicrm_activity.campaign_id
+                    LEFT JOIN civicrm_segmentation_order ON civicrm_segmentation_order.segment_id=civicrm_segmentation.segment_id
+                                                        AND civicrm_segmentation_order.campaign_id=civicrm_segmentation.campaign_id
+                    WHERE civicrm_activity_contact.activity_id = %0
+                      AND civicrm_activity_contact.contact_id = %1
+                    ORDER BY order_number
+                    LIMIT 1)";
     CRM_Core_DAO::executeQuery($query, [
       [$activity_id, 'Integer'],
       [$contact_id, 'Integer'],

--- a/CRM/Segmentation/Upgrader.php
+++ b/CRM/Segmentation/Upgrader.php
@@ -1,0 +1,16 @@
+<?php
+
+use CRM_Segmentation_ExtensionUtil as E;
+
+/**
+ * Collection of upgrade steps.
+ */
+class CRM_Segmentation_Upgrader extends CRM_Segmentation_Upgrader_Base {
+
+  public function upgrade_0900() {
+    $this->ctx->log->info('Updating segmentation schema to 0.9.0');
+    $this->executeSqlFile('sql/create_activity_contact_segmentation.sql');
+    return TRUE;
+  }
+
+}

--- a/CRM/Segmentation/Upgrader/Base.php
+++ b/CRM/Segmentation/Upgrader/Base.php
@@ -1,0 +1,376 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+use CRM_Segmentation_ExtensionUtil as E;
+
+/**
+ * Base class which provides helpers to execute upgrade logic
+ */
+class CRM_Segmentation_Upgrader_Base {
+
+  /**
+   * @var varies, subclass of this
+   */
+  static $instance;
+
+  /**
+   * @var CRM_Queue_TaskContext
+   */
+  protected $ctx;
+
+  /**
+   * @var string, eg 'com.example.myextension'
+   */
+  protected $extensionName;
+
+  /**
+   * @var string, full path to the extension's source tree
+   */
+  protected $extensionDir;
+
+  /**
+   * @var array(revisionNumber) sorted numerically
+   */
+  private $revisions;
+
+  /**
+   * @var boolean
+   *   Flag to clean up extension revision data in civicrm_setting
+   */
+  private $revisionStorageIsDeprecated = FALSE;
+
+  /**
+   * Obtain a reference to the active upgrade handler.
+   */
+  static public function instance() {
+    if (!self::$instance) {
+      // FIXME auto-generate
+      self::$instance = new CRM_Segmentation_Upgrader(
+        'de.systopia.segmentation',
+        realpath(__DIR__ . '/../../../')
+      );
+    }
+    return self::$instance;
+  }
+
+  /**
+   * Adapter that lets you add normal (non-static) member functions to the queue.
+   *
+   * Note: Each upgrader instance should only be associated with one
+   * task-context; otherwise, this will be non-reentrant.
+   *
+   * @code
+   * CRM_Segmentation_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
+   * @endcode
+   */
+  static public function _queueAdapter() {
+    $instance = self::instance();
+    $args = func_get_args();
+    $instance->ctx = array_shift($args);
+    $instance->queue = $instance->ctx->queue;
+    $method = array_shift($args);
+    return call_user_func_array(array($instance, $method), $args);
+  }
+
+  public function __construct($extensionName, $extensionDir) {
+    $this->extensionName = $extensionName;
+    $this->extensionDir = $extensionDir;
+  }
+
+  // ******** Task helpers ********
+
+  /**
+   * Run a CustomData file.
+   *
+   * @param string $relativePath the CustomData XML file path (relative to this extension's dir)
+   * @return bool
+   */
+  public function executeCustomDataFile($relativePath) {
+    $xml_file = $this->extensionDir . '/' . $relativePath;
+    return $this->executeCustomDataFileByAbsPath($xml_file);
+  }
+
+  /**
+   * Run a CustomData file
+   *
+   * @param string $xml_file  the CustomData XML file path (absolute path)
+   *
+   * @return bool
+   */
+  protected static function executeCustomDataFileByAbsPath($xml_file) {
+    $import = new CRM_Utils_Migrate_Import();
+    $import->run($xml_file);
+    return TRUE;
+  }
+
+  /**
+   * Run a SQL file.
+   *
+   * @param string $relativePath the SQL file path (relative to this extension's dir)
+   *
+   * @return bool
+   */
+  public function executeSqlFile($relativePath) {
+    CRM_Utils_File::sourceSQLFile(
+      CIVICRM_DSN,
+      $this->extensionDir . DIRECTORY_SEPARATOR . $relativePath
+    );
+    return TRUE;
+  }
+
+  /**
+   * @param string $tplFile
+   *   The SQL file path (relative to this extension's dir).
+   *   Ex: "sql/mydata.mysql.tpl".
+   * @return bool
+   */
+  public function executeSqlTemplate($tplFile) {
+    // Assign multilingual variable to Smarty.
+    $upgrade = new CRM_Upgrade_Form();
+
+    $tplFile = CRM_Utils_File::isAbsolute($tplFile) ? $tplFile : $this->extensionDir . DIRECTORY_SEPARATOR . $tplFile;
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('domainID', CRM_Core_Config::domainID());
+    CRM_Utils_File::sourceSQLFile(
+      CIVICRM_DSN, $smarty->fetch($tplFile), NULL, TRUE
+    );
+    return TRUE;
+  }
+
+  /**
+   * Run one SQL query.
+   *
+   * This is just a wrapper for CRM_Core_DAO::executeSql, but it
+   * provides syntatic sugar for queueing several tasks that
+   * run different queries
+   */
+  public function executeSql($query, $params = array()) {
+    // FIXME verify that we raise an exception on error
+    CRM_Core_DAO::executeQuery($query, $params);
+    return TRUE;
+  }
+
+  /**
+   * Syntatic sugar for enqueuing a task which calls a function in this class.
+   *
+   * The task is weighted so that it is processed
+   * as part of the currently-pending revision.
+   *
+   * After passing the $funcName, you can also pass parameters that will go to
+   * the function. Note that all params must be serializable.
+   */
+  public function addTask($title) {
+    $args = func_get_args();
+    $title = array_shift($args);
+    $task = new CRM_Queue_Task(
+      array(get_class($this), '_queueAdapter'),
+      $args,
+      $title
+    );
+    return $this->queue->createItem($task, array('weight' => -1));
+  }
+
+  // ******** Revision-tracking helpers ********
+
+  /**
+   * Determine if there are any pending revisions.
+   *
+   * @return bool
+   */
+  public function hasPendingRevisions() {
+    $revisions = $this->getRevisions();
+    $currentRevision = $this->getCurrentRevision();
+
+    if (empty($revisions)) {
+      return FALSE;
+    }
+    if (empty($currentRevision)) {
+      return TRUE;
+    }
+
+    return ($currentRevision < max($revisions));
+  }
+
+  /**
+   * Add any pending revisions to the queue.
+   */
+  public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
+    $this->queue = $queue;
+
+    $currentRevision = $this->getCurrentRevision();
+    foreach ($this->getRevisions() as $revision) {
+      if ($revision > $currentRevision) {
+        $title = ts('Upgrade %1 to revision %2', array(
+          1 => $this->extensionName,
+          2 => $revision,
+        ));
+
+        // note: don't use addTask() because it sets weight=-1
+
+        $task = new CRM_Queue_Task(
+          array(get_class($this), '_queueAdapter'),
+          array('upgrade_' . $revision),
+          $title
+        );
+        $this->queue->createItem($task);
+
+        $task = new CRM_Queue_Task(
+          array(get_class($this), '_queueAdapter'),
+          array('setCurrentRevision', $revision),
+          $title
+        );
+        $this->queue->createItem($task);
+      }
+    }
+  }
+
+  /**
+   * Get a list of revisions.
+   *
+   * @return array(revisionNumbers) sorted numerically
+   */
+  public function getRevisions() {
+    if (!is_array($this->revisions)) {
+      $this->revisions = array();
+
+      $clazz = new ReflectionClass(get_class($this));
+      $methods = $clazz->getMethods();
+      foreach ($methods as $method) {
+        if (preg_match('/^upgrade_(.*)/', $method->name, $matches)) {
+          $this->revisions[] = $matches[1];
+        }
+      }
+      sort($this->revisions, SORT_NUMERIC);
+    }
+
+    return $this->revisions;
+  }
+
+  public function getCurrentRevision() {
+    $revision = CRM_Core_BAO_Extension::getSchemaVersion($this->extensionName);
+    if (!$revision) {
+      $revision = $this->getCurrentRevisionDeprecated();
+    }
+    return $revision;
+  }
+
+  private function getCurrentRevisionDeprecated() {
+    $key = $this->extensionName . ':version';
+    if ($revision = CRM_Core_BAO_Setting::getItem('Extension', $key)) {
+      $this->revisionStorageIsDeprecated = TRUE;
+    }
+    return $revision;
+  }
+
+  public function setCurrentRevision($revision) {
+    CRM_Core_BAO_Extension::setSchemaVersion($this->extensionName, $revision);
+    // clean up legacy schema version store (CRM-19252)
+    $this->deleteDeprecatedRevision();
+    return TRUE;
+  }
+
+  private function deleteDeprecatedRevision() {
+    if ($this->revisionStorageIsDeprecated) {
+      $setting = new CRM_Core_BAO_Setting();
+      $setting->name = $this->extensionName . ':version';
+      $setting->delete();
+      CRM_Core_Error::debug_log_message("Migrated extension schema revision ID for {$this->extensionName} from civicrm_setting (deprecated) to civicrm_extension.\n");
+    }
+  }
+
+  // ******** Hook delegates ********
+
+  /**
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+   */
+  public function onInstall() {
+    $files = glob($this->extensionDir . '/sql/*_install.sql');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
+      }
+    }
+    $files = glob($this->extensionDir . '/sql/*_install.mysql.tpl');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        $this->executeSqlTemplate($file);
+      }
+    }
+    $files = glob($this->extensionDir . '/xml/*_install.xml');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        $this->executeCustomDataFileByAbsPath($file);
+      }
+    }
+    if (is_callable(array($this, 'install'))) {
+      $this->install();
+    }
+  }
+
+  /**
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+   */
+  public function onPostInstall() {
+    $revisions = $this->getRevisions();
+    if (!empty($revisions)) {
+      $this->setCurrentRevision(max($revisions));
+    }
+    if (is_callable(array($this, 'postInstall'))) {
+      $this->postInstall();
+    }
+  }
+
+  /**
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+   */
+  public function onUninstall() {
+    $files = glob($this->extensionDir . '/sql/*_uninstall.mysql.tpl');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        $this->executeSqlTemplate($file);
+      }
+    }
+    if (is_callable(array($this, 'uninstall'))) {
+      $this->uninstall();
+    }
+    $files = glob($this->extensionDir . '/sql/*_uninstall.sql');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
+      }
+    }
+  }
+
+  /**
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+   */
+  public function onEnable() {
+    // stub for possible future use
+    if (is_callable(array($this, 'enable'))) {
+      $this->enable();
+    }
+  }
+
+  /**
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+   */
+  public function onDisable() {
+    // stub for possible future use
+    if (is_callable(array($this, 'disable'))) {
+      $this->disable();
+    }
+  }
+
+  public function onUpgrade($op, CRM_Queue_Queue $queue = NULL) {
+    switch ($op) {
+      case 'check':
+        return array($this->hasPendingRevisions());
+
+      case 'enqueue':
+        return $this->enqueuePendingRevisions($queue);
+
+      default:
+    }
+  }
+
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/segmentation.civix.php
+++ b/segmentation.civix.php
@@ -3,6 +3,83 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Segmentation_ExtensionUtil {
+  const SHORT_NAME = "segmentation";
+  const LONG_NAME = "de.systopia.segmentation";
+  const CLASS_PREFIX = "CRM_Segmentation";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = array()) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = array(self::LONG_NAME, NULL);
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Segmentation_ExtensionUtil as E;
+
+/**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
@@ -190,7 +267,7 @@ function _segmentation_civix_civicrm_managed(&$entities) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'de.systopia.segmentation';
+        $e['module'] = E::LONG_NAME;
       }
       $entities[] = $e;
       if (empty($e['params']['version'])) {
@@ -222,7 +299,7 @@ function _segmentation_civix_civicrm_caseTypes(&$caseTypes) {
       // throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = array(
-      'module' => 'de.systopia.segmentation',
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
     );
@@ -248,7 +325,7 @@ function _segmentation_civix_civicrm_angularModules(&$angularModules) {
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
     $module = include $file;
     if (empty($module['ext'])) {
-      $module['ext'] = 'de.systopia.segmentation';
+      $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
   }
@@ -275,8 +352,10 @@ function _segmentation_civix_glob($pattern) {
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
- * @param string $path - path where insertion should happen (ie. Administer/System Settings)
- * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
  */
 function _segmentation_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
@@ -365,4 +444,17 @@ function _segmentation_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NU
   if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
     $metaDataFolders[] = $settingsDir;
   }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+
+function _segmentation_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, array (
+  ));
 }

--- a/segmentation.php
+++ b/segmentation.php
@@ -310,14 +310,12 @@ function segmentation_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($objectName == 'Activity' && $op == 'create') {
     $store = CRM_Segmentation_ActivityContactStore::getInstance();
     foreach ($store->popContacts() as $contact_id) {
-      CRM_Segmentation_Logic::addSegmentToActivityContact($objectId, $contact_id);
+      CRM_Segmentation_Logic::addSegmentForActivityContact($objectId, $contact_id);
     }
   }
 }
 
 function segmentation_civicrm_apiWrappers(&$wrappers, $apiRequest) {
-  //&apiWrappers is an array of wrappers, you can add your(s) with the hook.
-  // You can use the apiRequest to decide if you want to add the wrapper (eg. only wrap api.Contact.create)
   if ($apiRequest['entity'] == 'ActivityContact' && $apiRequest['action'] == 'create') {
     $wrappers[] = new CRM_Segmentation_ActivityContactCreateAPIWrapper();
   }

--- a/sql/civicrm_segment_index.sql
+++ b/sql/civicrm_segment_index.sql
@@ -18,3 +18,14 @@ CREATE TABLE IF NOT EXISTS `civicrm_segmentation_order`(
   INDEX `order_number` (order_number),
   INDEX `campaign_id` (campaign_id)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;
+
+-- CREATE SEGMENT TO ACTIVITY TABLE
+CREATE TABLE IF NOT EXISTS `civicrm_activity_contact_segmentation` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'ActivityContact Segment Entry ID',
+  `activity_contact_id` INT UNSIGNED NOT NULL COMMENT 'ActivityContact ID',
+  `segment_id` INT UNSIGNED NOT NULL COMMENT 'Segment ID',
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `activity_contact_id_UNIQUE` (`activity_contact_id` ASC),
+  CONSTRAINT `FK_civicrm_activity_contact_segmentation_activity_contact_id` FOREIGN KEY (`activity_contact_id`) REFERENCES `civicrm_activity_contact` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `FK_civicrm_activity_contact_segmentation_segment_id` FOREIGN KEY (`segment_id`) REFERENCES `civicrm_segmentation_index` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;

--- a/sql/create_activity_contact_segmentation.sql
+++ b/sql/create_activity_contact_segmentation.sql
@@ -1,0 +1,10 @@
+-- CREATE SEGMENT TO ACTIVITY TABLE
+CREATE TABLE IF NOT EXISTS `civicrm_activity_contact_segmentation` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'ActivityContact Segment Entry ID',
+  `activity_contact_id` INT UNSIGNED NOT NULL COMMENT 'ActivityContact ID',
+  `segment_id` INT UNSIGNED NOT NULL COMMENT 'Segment ID',
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `activity_contact_id_UNIQUE` (`activity_contact_id` ASC),
+  CONSTRAINT `FK_civicrm_activity_contact_segmentation_activity_contact_id` FOREIGN KEY (`activity_contact_id`) REFERENCES `civicrm_activity_contact` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `FK_civicrm_activity_contact_segmentation_segment_id` FOREIGN KEY (`segment_id`) REFERENCES `civicrm_segmentation_index` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;

--- a/tests/phpunit/CRM/Segmentation/ActivityContactTest.php
+++ b/tests/phpunit/CRM/Segmentation/ActivityContactTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use CRM_Segmentation_ExtensionUtil as E;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Tests the creation of ActivityContact segmentation rows
+ * (civicrm_activity_contact_segmentation) in various scenarios
+ *
+ * @group headless
+ */
+class CRM_Segmentation_ActivityContactTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+  use \Civi\Test\Api3TestTrait;
+
+  private $_campaignId;
+  private $_segmentId;
+  private $_sourceContactId;
+  private $_activityId;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp() {
+    $this->_campaignId = $this->callApiSuccess('Campaign', 'create', [
+      'title' => 'Test Campaign',
+    ])['id'];
+
+    $this->_segmentId = $this->callApiSuccess('Segmentation', 'getsegmentid', [
+      'name' => 'Test Segment',
+    ])['id'];
+
+    CRM_Core_DAO::executeQuery("
+          INSERT IGNORE INTO `civicrm_segmentation` (entity_id,datetime,campaign_id,segment_id,test_group,membership_id)
+          SELECT civicrm_contact.id AS entity_id,
+                 NOW()              AS datetime,
+                 %0                 AS campaign_id,
+                 %1                 AS segment_id,
+                 NULL               AS test_group,
+                 NULL               AS membership_id
+          FROM civicrm_contact WHERE civicrm_contact.id IN (1, 2)",
+      [
+        [$this->_campaignId, 'Integer'],
+        [$this->_segmentId, 'Integer'],
+      ]
+    );
+
+    $this->_sourceContactId = $this->callApiSuccess('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Dummy source contact',
+    ])['id'];
+
+    $this->_activityId = $this->callApiSuccess('Activity', 'create', [
+      'campaign_id' => $this->_campaignId,
+      'activity_type_id' => 1,
+      'source_contact_id' => $this->_sourceContactId,
+    ])['id'];
+
+    // add segement to order
+    CRM_Segmentation_Logic::addSegmentToCampaign($this->_segmentId, $this->_campaignId);
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  public function testActivityContactCreate() {
+    $this->callApiSuccess('ActivityContact', 'create', [
+      'activity_id' => $this->_activityId,
+      'contact_id' => 1,
+    ]);
+
+    $query = CRM_Core_DAO::executeQuery("SELECT COUNT(*) AS count FROM civicrm_activity_contact_segmentation acs
+                             INNER JOIN civicrm_activity_contact ac ON ac.id = acs.activity_contact_id
+                             WHERE ac.contact_id = 1 AND ac.activity_id = {$this->_activityId}");
+    $query->fetch();
+    $this->assertEquals(1, $query->count, 'ActivityContact.create should create segmentation');
+
+    $query = CRM_Core_DAO::executeQuery("SELECT COUNT(*) AS count FROM civicrm_activity_contact_segmentation acs
+                             INNER JOIN civicrm_activity_contact ac ON ac.id = acs.activity_contact_id
+                             WHERE ac.contact_id = 2 AND ac.activity_id = {$this->_activityId}");
+    $query->fetch();
+    $this->assertEquals(0, $query->count, 'ActivityContact.create with contact_id=1 should not create segmentation contact_id=2');
+  }
+
+  public function testActivityCreateWithContact() {
+    $activity_id = $this->callApiSuccess('Activity', 'create', [
+      'campaign_id' => $this->_campaignId,
+      'activity_type_id' => 1,
+      'source_contact_id' => $this->_sourceContactId,
+      'target_id' => 2
+    ])['id'];
+
+    $query = CRM_Core_DAO::executeQuery("SELECT COUNT(*) AS count FROM civicrm_activity_contact_segmentation acs
+                             INNER JOIN civicrm_activity_contact ac ON ac.id = acs.activity_contact_id
+                             WHERE ac.contact_id = 2 AND ac.activity_id = {$activity_id}");
+    $query->fetch();
+    $this->assertEquals(1, $query->count, 'Activity.create with target_id should create segmentation');
+
+    $query = CRM_Core_DAO::executeQuery("SELECT COUNT(*) AS count FROM civicrm_activity_contact_segmentation acs
+                             INNER JOIN civicrm_activity_contact ac ON ac.id = acs.activity_contact_id
+                             WHERE ac.contact_id = 1 AND ac.activity_id = {$activity_id}");
+    $query->fetch();
+    $this->assertEquals(0, $query->count, 'Activity.create with target_id=2 should not create segmentation for contact_id=1');
+  }
+
+  public function testMassActivity() {
+    $query = "INSERT IGNORE INTO civicrm_activity_contact
+                   (SELECT
+                      NULL               AS id,
+                      {$this->_activityId}  AS activity_id,
+                      civicrm_contact.id AS contact_id,
+                      3                  AS record_type
+                    FROM civicrm_segmentation
+                    LEFT JOIN civicrm_contact ON civicrm_contact.id = civicrm_segmentation.entity_id
+                    WHERE campaign_id = {$this->_campaignId}
+                      AND civicrm_contact.is_deleted = 0)";
+    CRM_Core_DAO::executeQuery($query);
+
+    CRM_Segmentation_Logic::addSegmentForMassActivity($this->_activityId, $this->_campaignId);
+
+    $query = CRM_Core_DAO::executeQuery("SELECT COUNT(*) AS count FROM civicrm_activity_contact_segmentation acs
+                             INNER JOIN civicrm_activity_contact ac ON ac.id = acs.activity_contact_id
+                             WHERE ac.activity_id = {$this->_activityId}");
+    $query->fetch();
+    $this->assertEquals(2, $query->count, 'CRM_Segmentation_Logic::addSegmentForMassActivity should create segmentation for two contacts');
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,62 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
This creates a new `civicrm_activity_contact_segmentation` table to track `segment_id`s for every `ActivityContact`. Rows are created when:

 - ActivityContact entities are created via an `ActivityContact.create` API call
 - Activities are created with `target_contact_id` being set (via `Activity.create` API or `Activity` BAO)
 - Activities are assigned through the campaign extension

*Important:* This code contains schema changes that will be applied through an updater.

This also adds tests for the new code. Note: Test code targets CiviCRM 4.7.1+; manual testing was performed against 4.6.22.

Fixes #2