### PR TITLE
Add bucket (A/B) and exclusion tests

### DIFF
--- a/CRM/Segmentation/Configuration.php
+++ b/CRM/Segmentation/Configuration.php
@@ -213,7 +213,9 @@ class CRM_Segmentation_Configuration {
      FROM civicrm_segmentation
      LEFT JOIN civicrm_segmentation_index ON civicrm_segmentation_index.id = civicrm_segmentation.segment_id
      LEFT JOIN civicrm_contact ON civicrm_contact.id = civicrm_segmentation.entity_id
-     WHERE campaign_id = {$_campaign_id}
+     LEFT JOIN civicrm_segmentation_order ON civicrm_segmentation_order.campaign_id = civicrm_segmentation.campaign_id
+       AND civicrm_segmentation_order.segment_id = civicrm_segmentation.segment_id
+     WHERE civicrm_segmentation.campaign_id = {$_campaign_id}
      {$contact_status_check}
      {$segment_condition}
      {$assignment_start_condition}

--- a/CRM/Segmentation/Form/CreateActivity.php
+++ b/CRM/Segmentation/Form/CreateActivity.php
@@ -187,7 +187,8 @@ class CRM_Segmentation_Form_CreateActivity extends CRM_Core_Form {
                       3                  AS record_type
                     FROM civicrm_segmentation
                     LEFT JOIN civicrm_contact ON civicrm_contact.id = civicrm_segmentation.entity_id
-                    WHERE campaign_id = {$values['cid']}
+                    LEFT JOIN civicrm_segmentation_order ON civicrm_segmentation_order.campaign_id = civicrm_segmentation.campaign_id AND civicrm_segmentation_order.segment_id = civicrm_segmentation.segment_id
+                    WHERE civicrm_segmentation.campaign_id = {$values['cid']}
                       AND civicrm_contact.is_deleted = 0)";
         CRM_Core_DAO::executeQuery($query);
 

--- a/CRM/Segmentation/Form/Split.php
+++ b/CRM/Segmentation/Form/Split.php
@@ -1,0 +1,167 @@
+<?php
+/*-------------------------------------------------------+
+| SYSTOPIA Contact Segmentation Extension                |
+| Copyright (C) 2018 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++--------------------------------------------------------*/
+
+/**
+ * Segment Split Form
+ */
+class CRM_Segmentation_Form_Split extends CRM_Core_Form {
+
+  protected $campaign = NULL;
+
+  protected $segment = NULL;
+
+  public function buildQuickForm() {
+    $cid = CRM_Utils_Request::retrieve('cid', 'Integer');
+    if (!$cid) {
+      CRM_Core_Session::setStatus(ts("No campaign ID (cid) given"), ts("Error"), "error");
+      $error_url = CRM_Utils_System::url('civicrm/dashboard');
+      CRM_Utils_System::redirect($error_url);
+    }
+
+    $sid = CRM_Utils_Request::retrieve('sid', 'Integer');
+    if (!$sid) {
+      CRM_Core_Session::setStatus(ts("No segment ID (sid) given"), ts("Error"), "error");
+      $error_url = CRM_Utils_System::url('civicrm/dashboard');
+      CRM_Utils_System::redirect($error_url);
+    }
+
+    $this->campaign = civicrm_api3('Campaign', 'getsingle', ['id' => $cid]);
+    $this->segment = civicrm_api3('Segmentation', 'getsingle', ['id' => $sid]);
+
+    CRM_Utils_System::setTitle(ts('Split Segment %1', [$this->segment['name']]));
+
+    $this->addElement('hidden', 'cid', $cid);
+    $this->addElement('hidden', 'sid', $sid);
+
+    $this->addRadio(
+      'split_type',
+      ts('Split Type'),
+      ['A/B Test', 'Exclusion Test'],
+      [],
+      NULL,
+      TRUE
+    );
+
+    // compile form
+    $this->add(
+      'text',
+      'segment[0]',
+      ts('Segment Name'),
+      ['class' => 'huge']
+    );
+
+    $this->add(
+      'text',
+      'segment[1]',
+      ts('Segment Name'),
+      ['class' => 'huge']
+    );
+
+    $this->add(
+      'text',
+      'exclude_contacts_total',
+      ts('Exclude Contacts'),
+      ['class' => 'eight']
+    );
+
+    $this->add(
+      'text',
+      'exclude_contacts_percentage',
+      ts('Exclude Percentage'),
+      ['class' => 'two']
+    );
+
+    $this->addRule("exclude_contacts_total", ts('Please enter a valid number.'), 'positiveInteger');
+    $this->addRule("exclude_contacts_percentage", ts('Please enter a valid number.'), 'positiveInteger');
+    $this->addFormRule(array('CRM_Segmentation_Form_Split', 'formRule'));
+
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => ts('Split'),
+        'isDefault' => TRUE,
+      ],
+    ]);
+
+    $this->setDefaults();
+    parent::buildQuickForm();
+  }
+
+  public static function formRule($fields) {
+    $errors = [];
+
+    if ($fields['split_type'] == '0') {
+      // bucket test
+      foreach ($fields['segment'] as $key => $segment) {
+        if (empty($segment)) {
+          $errors["segment[{$key}]"] = ts('Please enter a segment name.');
+        }
+      }
+    }
+    else {
+      // exclusion test
+      if (empty($fields['exclude_contacts_total']) && empty($fields['exclude_contacts_percentage'])) {
+        $errors["exclude_contacts_total"] = ts('Please provide a number or percentage of contacts to exclude.');
+      }
+    }
+
+    return empty($errors) ? TRUE : $errors;
+  }
+
+  public function setDefaults($defaultValues = NULL, $filter = NULL) {
+    $defaults['segment'][0] = $this->segment['name'] . ' / A';
+    $defaults['segment'][1] = $this->segment['name'] . ' / B';
+    $defaults['split_type'] = '0';
+    $defaults['exclude_contacts_total'] = '1000';
+    $defaults['exclude_contacts_percentage'] = '10';
+    parent::setDefaults($defaults);
+  }
+
+  public function postProcess() {
+    $values = $this->exportValues();
+
+    $segmentOrderId = CRM_Core_DAO::singleValueQuery(
+      "SELECT id FROM civicrm_segmentation_order
+      WHERE campaign_id=%0 AND segment_id=%1",
+      [[$values['cid'], 'Integer'], [$values['sid'], 'Integer']]
+    );
+    $splitBuckets = [];
+    if ($values['split_type'] == '0') {
+      // perform A/B test
+      foreach ($values['segment'] as $segment) {
+        $splitBuckets[] = $segment;
+      }
+      civicrm_api3('SegmentationOrder', 'split', [
+        'id' => $segmentOrderId,
+        'buckets' => $splitBuckets,
+      ]);
+    }
+    else {
+      // exclusion test
+      civicrm_api3('SegmentationOrder', 'split', [
+        'id' => $segmentOrderId,
+        'exclude_total' => $values['exclude_contacts_total'],
+        'exclude_percentage' => $values['exclude_contacts_percentage'],
+      ]);
+    }
+
+    parent::postProcess();
+    CRM_Core_Session::setStatus(ts('Segment successfully split.'), ts('Success'), 'info');
+    $start_url = CRM_Utils_System::url('civicrm/segmentation/start', ['cid' => ((int) $values['cid'])]);
+    CRM_Utils_System::redirect($start_url);
+  }
+
+}

--- a/CRM/Segmentation/Logic.php
+++ b/CRM/Segmentation/Logic.php
@@ -260,6 +260,36 @@ class CRM_Segmentation_Logic {
   }
 
   /**
+   * get a list segment_id -> contact_count for the given campaign
+   *
+   */
+  public static function getExcludedCounts($campaign_id, $segment_order = array()) {
+    self::verifySegmentOrder($campaign_id);
+    $timestamp = microtime(TRUE);
+    $campaign_id = (int) $campaign_id;
+    $segment_counts = array();
+    foreach ($segment_order as $segment_id) {
+      $segment_counts[$segment_id] = 0;
+    }
+
+    $query = CRM_Core_DAO::executeQuery("
+      SELECT
+        segment_id,
+        COUNT(DISTINCT(contact_id)) AS contact_count
+      FROM civicrm_segmentation_exclude
+      WHERE campaign_id = %0
+      GROUP BY segment_id", [[$campaign_id, 'Integer']]);
+    while ($query->fetch()) {
+      $segment_counts[$query->segment_id] = $query->contact_count;
+    }
+
+    $runtime = microtime(TRUE) - $timestamp;
+    error_log("Segmentation::getExcludedCounts took {$runtime}s");
+
+    return $segment_counts;
+  }
+
+  /**
    * get a list segment_id -> segment_title for the given segment ids
    *
    * @todo move to another class

--- a/CRM/Segmentation/Page/Start.php
+++ b/CRM/Segmentation/Page/Start.php
@@ -57,6 +57,9 @@ class CRM_Segmentation_Page_Start extends CRM_Core_Page {
       $segments[$segmentId]['count'] = $segmentCount;
       $total_count += $segmentCount;
     }
+    foreach (CRM_Segmentation_Logic::getExcludedCounts($campaign_id, $segment_order) as $segmentId => $segmentCount) {
+      $segments[$segmentId]['excluded_count'] = $segmentCount;
+    }
     $this->assign('segments', $segments);
     $this->assign('segment_order', $segment_order);
     $this->assign('campaign', $campaign);

--- a/CRM/Segmentation/Page/View/CustomData.php
+++ b/CRM/Segmentation/Page/View/CustomData.php
@@ -25,7 +25,7 @@ class CRM_Segmentation_Page_View_CustomData {
     }
 
     // compile segments data
-    $segments_query = civicrm_api3('Segmentation', 'segmentlist', array('contact_id' => $page->_contactId));
+    $segments_query = civicrm_api3('Segmentation', 'segmentlist', ['contact_id' => $page->_contactId, 'include_excluded' => true]);
     $segments_details = $segments_query['values'];
 
     // compile campaign data

--- a/CRM/Segmentation/SegmentationOrder.php
+++ b/CRM/Segmentation/SegmentationOrder.php
@@ -29,7 +29,7 @@ class CRM_Segmentation_SegmentationOrder {
    *
    * @return array segment_id, name, bundle, text_block, order
    */
-  public static function getSegmentationOrderByCampaignAndSegmentList($campaignId, $segmentIds) {
+  public static function getSegmentationOrderByCampaignAndSegmentList($campaignId, array $segmentIds) {
     $campaignId = (int) $campaignId;
     $segmentIdList = implode(',', array_map('intval', $segmentIds));
     if (empty($segmentIdList)) {
@@ -47,24 +47,24 @@ class CRM_Segmentation_SegmentationOrder {
     return $segments;
   }
 
-  public static function updateSegmentationOrder($segmentationOrderId, $data) {
+  public static function updateSegmentationOrder($segmentationOrderId, array $params) {
     $i = 0;
     $updateFields = [];
-    if (isset($data['order_number'])) {
+    if (isset($params['order_number'])) {
       $updateFields[] = "order_number = %{$i}";
-      $dbData[$i] = [$data['order_number'], 'Integer'];
+      $dbData[$i] = [$params['order_number'], 'Integer'];
       $i++;
     }
 
-    if (isset($data['bundle'])) {
+    if (isset($params['bundle'])) {
       $updateFields[] = "bundle = %{$i}";
-      $dbData[$i] = [$data['bundle'], 'String'];
+      $dbData[$i] = [$params['bundle'], 'String'];
       $i++;
     }
 
-    if (isset($data['text_block'])) {
+    if (isset($params['text_block'])) {
       $updateFields[] = "text_block = %{$i}";
-      $dbData[$i] = [$data['text_block'], 'String'];
+      $dbData[$i] = [$params['text_block'], 'String'];
       $i++;
     }
 
@@ -79,6 +79,43 @@ class CRM_Segmentation_SegmentationOrder {
                                                 SET {$updateQuery}
                                                 WHERE id = %{$i}", $dbData);
     return self::getSegmentationOrder($segmentationOrderId);
+  }
+
+  public static function createSegmentationOrder(array $params) {
+    CRM_Core_DAO::executeQuery(
+      "INSERT INTO civicrm_segmentation_order (campaign_id, segment_id, order_number, bundle, text_block) VALUES (%0, %1, %2, %3, %4)",
+      [
+        [$params['campaign_id'], 'Integer'],
+        [$params['segment_id'], 'Integer'],
+        [$params['order_number'], 'Integer'],
+        [$params['bundle'], 'String'],
+        [$params['text_block'], 'String'],
+      ]
+    );
+    return current(CRM_Segmentation_SegmentationOrder::getSegmentationOrderByCampaignAndSegmentList($params['campaign_id'], [$params['segment_id']]));
+  }
+
+  /**
+   * Check whether a segment name is in use in a campaign.
+   *
+   * Optionally, you can exclude a specific segment using $excludedSegmentId.
+   *
+   * @param $campaignId
+   * @param $name
+   * @param null $excludedSegmentId
+   *
+   * @return bool whether the segment name is available
+   */
+  public static function isSegmentNameAvailable($campaignId, $name, $excludedSegmentId = NULL) {
+    $query = "SELECT COUNT(*) AS count FROM civicrm_segmentation_order
+                INNER JOIN civicrm_segmentation_index ON civicrm_segmentation_index.id = civicrm_segmentation_order.segment_id
+                WHERE campaign_id = %0 AND name = %1";
+    $data = [[$campaignId, 'Integer'], [$name, 'String']];
+    if (!is_null($excludedSegmentId)) {
+      $query .= " AND segment_id != %2";
+      $data[] = [$excludedSegmentId, 'Integer'];
+    }
+    return 0 == CRM_Core_DAO::singleValueQuery($query, $data);
   }
 
 }

--- a/CRM/Segmentation/Upgrader.php
+++ b/CRM/Segmentation/Upgrader.php
@@ -10,18 +10,24 @@ class CRM_Segmentation_Upgrader extends CRM_Segmentation_Upgrader_Base {
   public function upgrade_0900() {
     $this->ctx->log->info('Updating segmentation schema to 0.9.0');
     $this->executeSqlFile('sql/create_activity_contact_segmentation.sql');
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferences();
     return TRUE;
   }
 
   public function upgrade_0910() {
     $this->ctx->log->info('Updating segmentation schema to 0.9.1');
     $this->executeSqlFile('sql/add_bundle_and_text_block.sql');
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferences();
     return TRUE;
   }
 
   public function upgrade_0920() {
     $this->ctx->log->info('Updating segmentation schema to 0.9.2');
     $this->executeSqlFile('sql/create_segmentation_exclude.sql');
+    $logging = new CRM_Logging_Schema();
+    $logging->fixSchemaDifferences();
     return TRUE;
   }
 

--- a/CRM/Segmentation/Upgrader.php
+++ b/CRM/Segmentation/Upgrader.php
@@ -19,4 +19,10 @@ class CRM_Segmentation_Upgrader extends CRM_Segmentation_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_0920() {
+    $this->ctx->log->info('Updating segmentation schema to 0.9.2');
+    $this->executeSqlFile('sql/create_segmentation_exclude.sql');
+    return TRUE;
+  }
+
 }

--- a/api/v3/Segmentation/Get.php
+++ b/api/v3/Segmentation/Get.php
@@ -1,0 +1,57 @@
+<?php
+
+use CRM_Segmentation_ExtensionUtil as E;
+
+/**
+ * Segmentation.Get API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ *
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_segmentation_get_spec(&$spec) {
+  $spec = [
+    'id' => [
+      'title' => 'Segmentation ID',
+      'api.required' => TRUE,
+      'type' => CRM_Utils_Type::T_INT,
+    ],
+  ];
+}
+
+/**
+ * Segmentation.Get API
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ * @throws API_Exception
+ */
+function civicrm_api3_segmentation_get($params) {
+  if (empty($params['id'])) {
+    return civicrm_api3_create_error('Parameter "id" is required.');
+  }
+  $query = CRM_Core_DAO::executeQuery("SELECT id, name FROM civicrm_segmentation_index WHERE civicrm_segmentation_index.id=%0", [
+    [
+      $params['id'],
+      'Integer',
+    ],
+  ]);
+  $query->fetch();
+  return civicrm_api3_create_success(
+    [
+      [
+        'id' => $query->id,
+        'name' => $query->name,
+      ],
+    ],
+    $params,
+    'Segmentation',
+    'Get'
+  );
+
+}

--- a/api/v3/SegmentationOrder/Create.php
+++ b/api/v3/SegmentationOrder/Create.php
@@ -1,4 +1,5 @@
 <?php
+
 use CRM_Segmentation_ExtensionUtil as E;
 
 /**
@@ -6,6 +7,7 @@ use CRM_Segmentation_ExtensionUtil as E;
  * This is used for documentation and validation.
  *
  * @param array $spec description of fields supported by this API call
+ *
  * @return void
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
  */
@@ -13,7 +15,14 @@ function _civicrm_api3_segmentation_order_create_spec(&$spec) {
   $spec = [
     'id' => [
       'title' => 'Segmentation Order ID',
-      'api.required' => TRUE,
+      'type' => CRM_Utils_Type::T_INT,
+    ],
+    'campaign_id' => [
+      'title' => 'Campaign',
+      'type' => CRM_Utils_Type::T_INT,
+    ],
+    'segment_id' => [
+      'title' => 'Segment',
       'type' => CRM_Utils_Type::T_INT,
     ],
     'order_number' => [
@@ -22,11 +31,13 @@ function _civicrm_api3_segmentation_order_create_spec(&$spec) {
     ],
     'bundle' => [
       'title' => 'Bundle',
-      'type' => CRM_Utils_Type::T_TEXT
+      'type' => CRM_Utils_Type::T_TEXT,
+      'api.default' => '',
     ],
     'text_block' => [
       'title' => 'Text Block',
-      'type' => CRM_Utils_Type::T_TEXT
+      'type' => CRM_Utils_Type::T_TEXT,
+      'api.default' => '',
     ],
   ];
 }
@@ -35,6 +46,7 @@ function _civicrm_api3_segmentation_order_create_spec(&$spec) {
  * SegmentationOrder.Create API
  *
  * @param array $params
+ *
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
@@ -42,10 +54,13 @@ function _civicrm_api3_segmentation_order_create_spec(&$spec) {
  */
 function civicrm_api3_segmentation_order_create($params) {
   if (empty($params['id'])) {
-    return civicrm_api3_create_error('Creating new SegmentationOrder entities is not supported yet.');
+    $data = CRM_Segmentation_SegmentationOrder::createSegmentationOrder($params);
+  }
+  else {
+    $data = CRM_Segmentation_SegmentationOrder::updateSegmentationOrder($params['id'], $params);
   }
   return civicrm_api3_create_success(
-    [CRM_Segmentation_SegmentationOrder::updateSegmentationOrder($params['id'], $params)],
+    [$data],
     $params,
     'SegmentationOrder',
     'Create'

--- a/api/v3/SegmentationOrder/Split.php
+++ b/api/v3/SegmentationOrder/Split.php
@@ -1,0 +1,240 @@
+<?php
+
+use CRM_Segmentation_ExtensionUtil as E;
+
+/**
+ * SegmentationOrder.Split API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ *
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_segmentation_order_split_spec(&$spec) {
+  $spec = [
+    'id' => [
+      'title' => 'Segmentation Order ID',
+      'api.required' => TRUE,
+      'type' => CRM_Utils_Type::T_INT,
+    ],
+    'buckets' => [
+      'title' => 'Buckets',
+      'description' => "Array of bucket names",
+
+    ],
+    'exclude_total' => [
+      'title' => 'Exclude Number of Contacts',
+      'description' => "Total number of contacts to exclude. Serves as an upper limit if exclude_percentage is present.",
+      'type' => CRM_Utils_Type::T_INT,
+    ],
+    'exclude_percentage' => [
+      'title' => 'Exclude Percentage of Contacts',
+      'description' => "Percentage of contacts to exclude. Can be capped via exclude_total.",
+      'type' => CRM_Utils_Type::T_INT,
+    ],
+  ];
+}
+
+function _civicrm_api3_segmentation_order_split_buckets($params) {
+  $query = CRM_Core_DAO::executeQuery("SELECT campaign_id, segment_id, order_number, bundle, text_block FROM civicrm_segmentation_order WHERE civicrm_segmentation_order.id=%0", [
+    [
+      $params['id'],
+      'Integer',
+    ],
+  ]);
+  if (!$query->fetch()) {
+    return civicrm_api3_create_error("SegmentationOrder with ID {$params['id']} not found.");
+  }
+
+  $campaign_id = $query->campaign_id;
+  $segment_id = $query->segment_id;
+  $order_number = $query->order_number;
+  $bundle = $query->bundle;
+  $text_block = $query->text_block;
+
+  // are the bucket names unique?
+  if (count($params['buckets']) !== count(array_unique($params['buckets']))) {
+    return civicrm_api3_create_error("Bucket names are not unique.");
+  }
+
+  // are the bucket names already in use as segment names in this campaign?
+  foreach ($params['buckets'] as $bucket) {
+    if (!CRM_Segmentation_SegmentationOrder::isSegmentNameAvailable($campaign_id, $bucket, $segment_id)) {
+      return civicrm_api3_create_error("Segment with name {$bucket} already exists in this campaign.");
+    }
+  }
+
+  // make sure the segment order is clean
+  CRM_Segmentation_Logic::verifySegmentOrder($campaign_id);
+
+  $bucketCount = count($params['buckets']);
+
+  // make space for new segments: Move each segment with order_number > the
+  // segment being split n steps down, where n is the number of buckets to be
+  // created - 1 (since the segment being split already has the right order)
+  CRM_Core_DAO::executeQuery(
+    "UPDATE civicrm_segmentation_order
+    SET order_number = order_number + %0
+    WHERE civicrm_segmentation_order.campaign_id=%1 AND order_number > %2",
+    [
+      [$bucketCount - 1, 'Integer'],
+      [$campaign_id, 'Integer'],
+      [$order_number, 'Integer'],
+    ]
+  );
+
+  $counts = CRM_Segmentation_Logic::getSegmentCounts($campaign_id, CRM_Segmentation_Logic::getSegmentOrder($campaign_id));
+  if (array_key_exists($segment_id, $counts)) {
+    $countPerBucket = round($counts[$segment_id] / $bucketCount);
+  }
+  else {
+    $countPerBucket = 0;
+  }
+
+  CRM_Core_DAO::executeQuery(
+    "DELETE FROM civicrm_segmentation_order WHERE id=%0",
+    [
+      [$params['id'], 'Integer'],
+    ]
+  );
+  $buckets = [];
+  $i = 0;
+  foreach ($params['buckets'] as $bucket) {
+    $segment = civicrm_api3('Segmentation', 'getsegmentid', ['name' => $bucket]);
+    $buckets[] = reset(
+      civicrm_api3(
+        'SegmentationOrder',
+        'create',
+        [
+          'campaign_id' => $campaign_id,
+          'segment_id' => $segment['id'],
+          'order_number' => $order_number + $i,
+          'bundle' => (string) $bundle,
+          'text_block' => (string) $text_block,
+        ]
+      )['values']
+    );
+
+    $limitSql = '';
+    $data = [
+      [$segment['id'], 'Integer'],
+      [$segment_id, 'Integer'],
+      [$campaign_id, 'Integer'],
+    ];
+    // set limit for everything but last bucket
+    if ($i + 1 != $bucketCount) {
+      $limitSql = 'ORDER BY RAND() LIMIT %3';
+      $data[] = [$countPerBucket, 'Integer'];
+    }
+    CRM_Core_DAO::executeQuery(
+      "UPDATE civicrm_segmentation
+      SET segment_id=%0
+      WHERE segment_id=%1 AND campaign_id=%2
+      {$limitSql}",
+      $data
+    );
+    $i++;
+  }
+
+  return civicrm_api3_create_success(
+    [$buckets],
+    $params,
+    'SegmentationOrder',
+    'Split'
+  );
+}
+
+function _civicrm_api3_segmentation_order_split_exclude($params) {
+  $query = CRM_Core_DAO::executeQuery("SELECT campaign_id, segment_id, order_number, name
+                                      FROM civicrm_segmentation_order
+                                      JOIN civicrm_segmentation_index ON civicrm_segmentation_index.id=civicrm_segmentation_order.segment_id
+                                      WHERE civicrm_segmentation_order.id=%0", [
+    [
+      $params['id'],
+      'Integer',
+    ],
+  ]);
+  if (!$query->fetch()) {
+    return civicrm_api3_create_error("SegmentationOrder with ID {$params['id']} not found.");
+  }
+
+  $campaign_id = $query->campaign_id;
+  $segment_id = $query->segment_id;
+  $name = $query->name;
+  $temp_table  = "temp_exclude_{$params['id']}_" . microtime();
+
+  // make sure the segment order is clean
+  CRM_Segmentation_Logic::verifySegmentOrder($campaign_id);
+
+  $counts = CRM_Segmentation_Logic::getSegmentCounts($campaign_id, CRM_Segmentation_Logic::getSegmentOrder($campaign_id));
+  if (!array_key_exists($segment_id, $counts)) {
+    return civicrm_api3_create_error("Cannot run exclusion test on segment without contacts.");
+  }
+
+  if (!empty($params['exclude_total']) && empty($params['exclude_percentage'])) {
+    $limit = $params['exclude_total'];
+  }
+  elseif (empty($params['exclude_total']) && !empty($params['exclude_percentage'])) {
+    $limit = round($params['exclude_percentage'] * $counts[$segment_id] / 100);
+  }
+  else {
+    $limit = min(round($params['exclude_percentage'] * $counts[$segment_id] / 100), $params['exclude_total']);
+  }
+
+  CRM_Core_DAO::executeQuery(
+    "CREATE TEMPORARY TABLE `{$temp_table}` AS
+      SELECT entity_id as contact_id, membership_id, datetime as created_date
+      FROM civicrm_segmentation
+      WHERE segment_id = %0 AND campaign_id = %1
+      ORDER BY RAND()
+      LIMIT %2",
+    [[$segment_id, 'Integer'], [$campaign_id, 'Integer'], [$limit, 'Integer']]
+  );
+
+  CRM_Core_DAO::executeQuery(
+    "INSERT INTO civicrm_segmentation_exclude (campaign_id, segment_id, contact_id, membership_id, created_date)
+      SELECT %0, %1, contact_id, membership_id, created_date
+      FROM `{$temp_table}`",
+    [[$campaign_id, 'Integer'], [$segment_id, 'Integer']]
+  );
+
+  CRM_Core_DAO::executeQuery(
+    "DELETE FROM civicrm_segmentation
+      WHERE segment_id = %0 AND campaign_id = %1 AND entity_id IN (SELECT contact_id FROM `{$temp_table}`)",
+    [[$segment_id, 'Integer'], [$campaign_id, 'Integer']]
+  );
+
+  CRM_Core_DAO::executeQuery("DROP TEMPORARY TABLE IF EXISTS `{$temp_table}`;");
+
+}
+
+/**
+ * SegmentationOrder.Split API
+ *
+ * @param array $params
+ *
+ * @return array API result descriptor
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ * @throws API_Exception
+ */
+function civicrm_api3_segmentation_order_split($params) {
+  if (empty($params['id'])) {
+    return civicrm_api3_create_error('Parameter "id" is required.');
+  }
+
+  if (!empty($params['buckets']) && (!empty($params['exclude_total']) || !empty($params['exclude_percentage']))) {
+    return civicrm_api3_create_error('Parameters "buckets" and "exclude" are mutually exclusive.');
+  }
+
+  if (!empty($params['buckets']) && count($params['buckets']) > 1) {
+    return _civicrm_api3_segmentation_order_split_buckets($params);
+  }
+
+  if (!empty($params['exclude_total']) || !empty($params['exclude_percentage'])) {
+    return _civicrm_api3_segmentation_order_split_exclude($params);
+  }
+
+  return civicrm_api3_create_error('One of "buckets" or "exclude" is required.');
+}

--- a/segmentation.php
+++ b/segmentation.php
@@ -216,6 +216,10 @@ function segmentation_civicrm_enable() {
   $sqlfile = dirname( __FILE__ ) . '/sql/civicrm_segment_index.sql';
   CRM_Utils_File::sourceSQLFile($config->dsn, $sqlfile);
 
+  // create segmentation exclude table
+  $sqlfile = dirname( __FILE__ ) . '/sql/create_segmentation_exclude.sql';
+  CRM_Utils_File::sourceSQLFile($config->dsn, $sqlfile);
+
   // add custom fields
   require_once 'CRM/Utils/CustomData.php';
   $customData = new CRM_Utils_CustomData('de.systopia.segmentation');

--- a/sql/create_segmentation_exclude.sql
+++ b/sql/create_segmentation_exclude.sql
@@ -1,0 +1,14 @@
+-- CREATE SEGMENTATION EXCLUDE TABLE
+CREATE TABLE IF NOT EXISTS `civicrm_segmentation_exclude` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'SegmentationExclude Entry ID',
+  `campaign_id` INT UNSIGNED NOT NULL COMMENT 'Campaign ID',
+  `segment_id` INT UNSIGNED NOT NULL COMMENT 'Segment ID',
+  `contact_id` INT UNSIGNED NOT NULL COMMENT 'Contact ID',
+  `membership_id` INT UNSIGNED NULL COMMENT 'Membership ID',
+  `created_date` TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT 'SegmentationExclude Entry Creation Date',
+  PRIMARY KEY (`id`),
+  CONSTRAINT `FK_civicrm_segmentation_exclude_campaign_id` FOREIGN KEY (`campaign_id`) REFERENCES `civicrm_campaign` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `FK_civicrm_segmentation_exclude_segment_id` FOREIGN KEY (`segment_id`) REFERENCES `civicrm_segmentation_index` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `FK_civicrm_segmentation_exclude_contact_id` FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `FK_civicrm_segmentation_exclude_membership_id` FOREIGN KEY (`membership_id`) REFERENCES `civicrm_membership` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;

--- a/templates/CRM/Segmentation/Form/Split.tpl
+++ b/templates/CRM/Segmentation/Form/Split.tpl
@@ -1,0 +1,120 @@
+{*-------------------------------------------------------+
+| SYSTOPIA Contact Segmentation Extension                |
+| Copyright (C) 2018 SYSTOPIA                            |
+| Author: B. Endres (endres@systopia.de)                 |
+| http://www.systopia.de/                                |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*}
+<div class="crm-block crm-form-block">
+  <div id="crm-segmentation-split-generic">
+    <p>
+      {ts}You can split segments to perform A/B or exclusion tests.{/ts}
+      <ol>
+        <li>{ts}Use A/B tests to split a segment into two or more buckets. Useful if you want to test the performance of different copy text variants, etc.{/ts}</li>
+        <li>{ts}Use exclusion tests to remove a subset of contacts from a segment. Test how contacts who receive a mailing perform compared to those who do not.{/ts}</li>
+      </ol>
+    </p>
+  </div>
+
+  <div class="crm-section">
+    <div class="label">{$form.split_type.label}</div>
+    <div class="content crm-segmentation-split-type">{$form.split_type.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  {$form.cid.html}
+  {$form.sid.html}
+
+  <div id="crm-segmentation-split-buckets">
+    <p>
+      {ts}Split segments into any number of buckets to perform A/B tests. A segment with 10,000 contacts and two buckets would be split into two segments with 5,000 contacts each.{/ts}
+      <ul>
+        <li>{ts}You can change the names of the new segments below{/ts}</li>
+        <li>{ts}Splits are always performed randomly and all buckets will have the same number of contacts (±1 for uneven totals){/ts}</li>
+        <li>{ts}This action cannot be undone once you hit "Split" below{/ts}</li>
+      </ul>
+    </p>
+    <table>
+      <thead class="sticky">
+      <tr>
+        <th>
+          #
+        </th>
+        <th>
+          {ts}Segment Name{/ts}
+        </th>
+      </tr>
+      </thead>
+      <tbody>
+      {foreach from=$form.segment item=segment}
+        <tr class="{cycle values="odd-row, even-row"}">
+          <td>
+            {counter}.
+          </td>
+          <td>
+            {$segment.html}
+          </td>
+        </tr>
+      {/foreach}
+      </tbody>
+    </table>
+  </div>
+
+  <div id="crm-segmentation-split-exclusion">
+    <p>
+      {ts}Contacts in an excluded segment will not be assigned to the campaign or be included in exports.{/ts}
+      <ul>
+        <li>{ts}You can enter an total number of contacts that should be excluded, or a percentage of contacts in the segment{/ts}</li>
+        <li>{ts}If you enter values in both fields, the total will be the upper limit of contacts to be added to the exclusion test (in case the percentage result is higher){/ts}</li>
+        <li>{ts}This action cannot be undone once you hit "Split" below{/ts}</li>
+      </ul>
+    </p>
+    <table class="form-layout-compressed">
+      <tr>
+        <td class="label">{$form.exclude_contacts_total.label}</td>
+        <td>{$form.exclude_contacts_total.html}</td>
+      </tr>
+      <tr>
+        <td class="label">{$form.exclude_contacts_percentage.label}</td>
+        <td>{$form.exclude_contacts_percentage.html} %</td>
+      </tr>
+    </table>
+  </div>
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+</div>
+
+<style type="text/css">
+{literal}
+  .crm-segmentation-split-type label {
+    padding-right: 5em;
+  }
+  #crm-segmentation-split-buckets, #crm-segmentation-split-exclusion {
+    display: none;
+  }
+{/literal}
+</style>
+
+<script type="text/javascript">
+{literal}
+  function showSplitType() {
+    if (CRM.$('input[name="split_type"]:checked').val() == '0') {
+      CRM.$('#crm-segmentation-split-buckets').show();
+      CRM.$('#crm-segmentation-split-exclusion').hide();
+    } else {
+      CRM.$('#crm-segmentation-split-exclusion').show();
+      CRM.$('#crm-segmentation-split-buckets').hide();
+    }
+  }
+  CRM.$('.crm-segmentation-split-type input[type="radio"]').change(showSplitType);
+  CRM.$(document).ready(showSplitType);
+{/literal}
+</script>

--- a/templates/CRM/Segmentation/Page/Start.tpl
+++ b/templates/CRM/Segmentation/Page/Start.tpl
@@ -61,7 +61,7 @@
         <a href="{crmURL p='civicrm/segmentation/start' q="cid=$campaign_id&delete=`$segment.segment_id`"}" alt="{ts}Delete Segment{/ts}" title="{ts}Delete the entire segment{/ts}" class="crm-hover-button">
           <div>{ts}Delete Segment{/ts}</div>
         </a>
-        {if $segment.exclude neq 1}
+        {if $segment.exclude neq 1 && $segment.count > 0 && $segment.excluded_count == 0}
         <a href="{crmURL p='civicrm/segmentation/split' q="cid=$campaign_id&sid=`$segment.segment_id`"}" alt="{ts}Split{/ts}" title="{ts}Split segment for A/B or exclusion tests{/ts}" class="crm-hover-button">
           <div>{ts}Split{/ts}</div>
         </a>

--- a/templates/CRM/Segmentation/Page/Start.tpl
+++ b/templates/CRM/Segmentation/Page/Start.tpl
@@ -28,14 +28,15 @@
 
 <table id="options" class="row-highlight">
   <thead>
-      <tr>
-          <th>{ts}Segment Name{/ts}</th>
-          <th>{ts}Contact Count{/ts}</th>
-          <th>{ts}Bundle{/ts}</th>
-          <th>{ts}Text Block{/ts}</th>
-          <th>{ts}Segment Order{/ts}</th>
-          <th>{ts}Actions{/ts}</th>
-      </tr>
+    <tr>
+      <th>{ts}Segment Name{/ts}</th>
+      <th>{ts}Contact Count{/ts}</th>
+      <th>{ts}Excluded{/ts}</th>
+      <th>{ts}Bundle{/ts}</th>
+      <th>{ts}Text Block{/ts}</th>
+      <th>{ts}Segment Order{/ts}</th>
+      <th>{ts}Actions{/ts}</th>
+    </tr>
   </thead>
   <tbody>
   {foreach from=$segments item=segment}
@@ -44,8 +45,9 @@
         <div class="" title="{$segment.name|escape}">{$segment.name|escape}</div>
       </td>
       <td class="crm-admin-options-value">{$segment.count}</td>
-      <td class="crm-admin-options-value crm-editable" data-field="bundle">{$segment.bundle|escape}</td>
-      <td class="crm-admin-options-value crm-editable" data-field="text_block">{$segment.text_block|escape}</td>
+      <td class="crm-admin-options-value">{$segment.excluded_count}</td>
+      <td class="crm-admin-options-value {if $segment.exclude neq 1}crm-editable{/if}" data-field="bundle">{$segment.bundle|escape}</td>
+      <td class="crm-admin-options-value {if $segment.exclude neq 1}crm-editable{/if}" data-field="text_block">{$segment.text_block|escape}</td>
       <td class="nowrap crm-admin-options-order">
           <a class="crm-weight-arrow" href="{crmURL p='civicrm/segmentation/start' q="cid=$campaign_id&top=`$segment.segment_id`"}"><img src="{$config->resourceBase}i/arrow/first.gif" title="Move to top" alt="Move to top" class="order-icon"></a>&nbsp;
           <a class="crm-weight-arrow" href="{crmURL p='civicrm/segmentation/start' q="cid=$campaign_id&up=`$segment.segment_id`"}"><img src="{$config->resourceBase}i/arrow/up.gif" title="Move up one row" alt="Move up one row" class="order-icon"></a>&nbsp;
@@ -59,6 +61,11 @@
         <a href="{crmURL p='civicrm/segmentation/start' q="cid=$campaign_id&delete=`$segment.segment_id`"}" alt="{ts}Delete Segment{/ts}" title="{ts}Delete the entire segment{/ts}" class="crm-hover-button">
           <div>{ts}Delete Segment{/ts}</div>
         </a>
+        {if $segment.exclude neq 1}
+        <a href="{crmURL p='civicrm/segmentation/split' q="cid=$campaign_id&sid=`$segment.segment_id`"}" alt="{ts}Split{/ts}" title="{ts}Split segment for A/B or exclusion tests{/ts}" class="crm-hover-button">
+          <div>{ts}Split{/ts}</div>
+        </a>
+        {/if}
       </td>
     </tr>
   {/foreach}

--- a/tests/phpunit/CRM/Segmentation/LogicTest.php
+++ b/tests/phpunit/CRM/Segmentation/LogicTest.php
@@ -25,6 +25,7 @@ class CRM_Segmentation_LogicTest extends \PHPUnit_Framework_TestCase implements 
   public function setUp() {
     $this->_campaignId = $this->callApiSuccess('Campaign', 'create', [
       'title' => 'Test Campaign',
+      'status_id' => 1,
     ])['id'];
 
     $this->_segments[] = $this->callApiSuccess('Segmentation', 'getsegmentid', [
@@ -147,4 +148,5 @@ class CRM_Segmentation_LogicTest extends \PHPUnit_Framework_TestCase implements 
       'CRM_Segmentation_Logic::setSegmentOrder should only have stored two segmentation order entries after deleting one'
     );
   }
+
 }

--- a/tests/phpunit/api/v3/Segmentation/GetTest.php
+++ b/tests/phpunit/api/v3/Segmentation/GetTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Segmentation.Get API Test Case
+ *
+ * @group headless
+ */
+class api_v3_Segmentation_GetTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+  use \Civi\Test\Api3TestTrait;
+
+  private $_segmentId;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp() {
+    $this->_segmentId = $this->callApiSuccess('Segmentation', 'getsegmentid', [
+      'name' => 'Test Segment 1',
+    ])['id'];
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Simple example test case.
+   *
+   * Note how the function name begins with the word "test".
+   */
+  public function testGetExisting() {
+    $segment = $this->callApiSuccess('Segmentation', 'Get', ['id' => $this->_segmentId]);
+    $this->assertEquals('Test Segment 1', $segment['values'][0]['name'], 'Segmentation.Get should return segment with the correct name');
+  }
+
+}

--- a/tests/phpunit/api/v3/SegmentationOrder/CreateTest.php
+++ b/tests/phpunit/api/v3/SegmentationOrder/CreateTest.php
@@ -39,11 +39,17 @@ class api_v3_SegmentationOrder_CreateTest extends \PHPUnit_Framework_TestCase im
   public function testUpdate() {
     CRM_Segmentation_Logic::setSegmentOrder($this->_campaignId, [$this->_segmentId]);
 
+    $segment_order_id = CRM_Core_DAO::singleValueQuery(
+      "SELECT id AS count FROM civicrm_segmentation_order
+                                          WHERE campaign_id=%0 AND segment_id=%1",
+      [[$this->_campaignId, 'Integer'], [$this->_segmentId, 'Integer']]
+    );
+
     $segmentationOrder = $this->callApiSuccess(
       'SegmentationOrder',
       'Create',
       [
-        'id' => $this->_segmentId,
+        'id' => $segment_order_id,
         'order_number' => 2,
         'bundle' => '1',
         'text_block' => 'example test block',

--- a/tests/phpunit/api/v3/SegmentationOrder/SplitTest.php
+++ b/tests/phpunit/api/v3/SegmentationOrder/SplitTest.php
@@ -1,0 +1,202 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * SegmentationOrder.Split API Test Case
+ *
+ * @group headless
+ */
+class api_v3_SegmentationOrder_SplitTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use \Civi\Test\Api3TestTrait;
+
+  private $_campaignId;
+
+  private $_firstSegmentId;
+
+  private $_secondSegmentId;
+
+  private $_segmentOrderId;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp() {
+    $this->_campaignId = $this->callApiSuccess('Campaign', 'create', [
+      'title' => 'Test Campaign',
+    ])['id'];
+    $this->_firstSegmentId = $this->callApiSuccess('Segmentation', 'getsegmentid', [
+      'name' => 'Test Segment 1',
+    ])['id'];
+    $this->_secondSegmentId = $this->callApiSuccess('Segmentation', 'getsegmentid', [
+      'name' => 'Test Segment 2',
+    ])['id'];
+    CRM_Segmentation_Logic::setSegmentOrder($this->_campaignId, [
+      $this->_firstSegmentId,
+      $this->_secondSegmentId,
+    ]);
+    $this->_segmentOrderId = CRM_Core_DAO::singleValueQuery(
+      "SELECT id FROM civicrm_segmentation_order
+      WHERE campaign_id=%0 AND segment_id=%1",
+      [[$this->_campaignId, 'Integer'], [$this->_firstSegmentId, 'Integer']]
+    );
+    // create and assign 10 contacts to each segment
+    for ($i = 0; $i < 20; $i++) {
+      $contactId = $this->callApiSuccess('Contact', 'create', [
+        'contact_type' => 'Individual',
+        'first_name' => 'test' . $i,
+      ])['id'];
+      if ($i < 10) {
+        $segmentId = $this->_firstSegmentId;
+      }
+      else {
+        $segmentId = $this->_secondSegmentId;
+      }
+      CRM_Core_DAO::executeQuery(
+        "INSERT INTO civicrm_segmentation (entity_id, datetime, campaign_id, segment_id) VALUES (%0, NOW(), %1, %2)",
+        [
+          [$contactId, 'Integer'],
+          [$this->_campaignId, 'Integer'],
+          [$segmentId, 'Integer'],
+        ]
+      );
+    }
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  public function testBucket() {
+    $this->callApiSuccess(
+      'SegmentationOrder',
+      'split',
+      [
+        'id' => $this->_segmentOrderId,
+        'buckets' => [
+          'Test Segment 1 / A',
+          'Test Segment 1 / B',
+          'Test Segment 1 / C',
+        ],
+      ]
+    );
+    $firstBucket = $this->callApiSuccess('Segmentation', 'getsegmentid', [
+      'name' => 'Test Segment 1 / A',
+    ])['id'];
+
+    $secondBucket = $this->callApiSuccess('Segmentation', 'getsegmentid', [
+      'name' => 'Test Segment 1 / B',
+    ])['id'];
+
+    $thirdBucket = $this->callApiSuccess('Segmentation', 'getsegmentid', [
+      'name' => 'Test Segment 1 / C',
+    ])['id'];
+
+    $counts = CRM_Segmentation_Logic::getSegmentCounts($this->_campaignId);
+
+    $this->assertEquals(3, $counts[$firstBucket], 'First bucket should have 3 contacts');
+    $this->assertEquals(3, $counts[$secondBucket], 'Second bucket should have 3 contacts');
+    $this->assertEquals(4, $counts[$thirdBucket], 'Third bucket should have 4 contacts');
+    $this->assertEquals(10, $counts[$this->_secondSegmentId], 'Original (second) segment should have 10 contacts');
+    $this->assertEquals(4, count($counts), 'Four segments should have assigned contacts');
+    $this->assertEquals(4, count(CRM_Segmentation_Logic::getSegmentOrder($this->_campaignId)), 'Four segments should be assigned to campaign');
+  }
+
+  public function testBucketWithDuplicateSegment() {
+    $this->callApiFailure(
+      'SegmentationOrder',
+      'split',
+      [
+        'id' => $this->_segmentOrderId,
+        'buckets' => [
+          'Test Segment 1',
+          'Test Segment 2',
+        ],
+      ],
+      'Segment with name Test Segment 2 already exists in this campaign.'
+    );
+  }
+
+  public function testBucketWithDuplicateBucket() {
+    $this->callApiFailure(
+      'SegmentationOrder',
+      'split',
+      [
+        'id' => $this->_segmentOrderId,
+        'buckets' => [
+          'Test Segment Duplicate',
+          'Test Segment Duplicate',
+        ],
+      ],
+      'Bucket names are not unique.'
+    );
+  }
+
+  public function testExclusionTotal() {
+    $this->callApiSuccess(
+      'SegmentationOrder',
+      'split',
+      [
+        'id' => $this->_segmentOrderId,
+        'exclude_total' => 2,
+      ]
+    );
+
+    $counts = CRM_Segmentation_Logic::getSegmentCounts($this->_campaignId);
+    $this->assertEquals(8, $counts[$this->_firstSegmentId], 'First segment should have 8 contacts');
+    $this->assertEquals(10, $counts[$this->_secondSegmentId], 'Second segment should have 10 contacts');
+    $this->assertEquals(2, count($counts), 'Two segments should have assigned contacts');
+    $this->assertEquals(2, count(CRM_Segmentation_Logic::getSegmentOrder($this->_campaignId)), 'Two segments should be assigned to campaign');
+  }
+
+  public function testExclusionPercentage() {
+    $this->callApiSuccess(
+      'SegmentationOrder',
+      'split',
+      [
+        'id' => $this->_segmentOrderId,
+        'exclude_percentage' => 30,
+      ]
+    );
+
+    $counts = CRM_Segmentation_Logic::getSegmentCounts($this->_campaignId);
+    $this->assertEquals(7, $counts[$this->_firstSegmentId], 'Segment should have 7 contacts');
+  }
+
+  public function testExclusionPercentageWithUpperLimitNotHit() {
+    $this->callApiSuccess(
+      'SegmentationOrder',
+      'split',
+      [
+        'id' => $this->_segmentOrderId,
+        'exclude_total' => 5,
+        'exclude_percentage' => 20,
+      ]
+    );
+
+    $counts = CRM_Segmentation_Logic::getSegmentCounts($this->_campaignId);
+    $this->assertEquals(8, $counts[$this->_firstSegmentId], 'Segment should have 8 contacts');
+  }
+
+  public function testExclusionPercentageWithUpperLimitHit() {
+    $this->callApiSuccess(
+      'SegmentationOrder',
+      'split',
+      [
+        'id' => $this->_segmentOrderId,
+        'exclude_total' => 4,
+        'exclude_percentage' => 60,
+      ]
+    );
+
+    $counts = CRM_Segmentation_Logic::getSegmentCounts($this->_campaignId);
+    $this->assertEquals(6, $counts[$this->_firstSegmentId], 'Segment should have 6 contacts');
+  }
+}

--- a/xml/Menu/segmentation.xml
+++ b/xml/Menu/segmentation.xml
@@ -30,4 +30,10 @@
     <title>CreateActivity</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/segmentation/split</path>
+    <page_callback>CRM_Segmentation_Form_Split</page_callback>
+    <title>Split</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
This adds support for two types of test segments:

- A/B or bucket tests can be used to split existing segments into multiple buckets to test variations of things like copy text. Conceptionally, A/B segments are just regular segments.
- Exclusion tests make it possible to exclude a number of contacts from a campaign to see how they perform compared to those who participated in a campaign. Excluded contacts are not included when activities are generated or campaigns are exported.