### PR TITLE
Make sure activity_id and contact_id are set in _post hook

### DIFF
--- a/segmentation.php
+++ b/segmentation.php
@@ -315,7 +315,9 @@ function segmentation_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($objectName == 'Activity' && $op == 'create') {
     $store = CRM_Segmentation_ActivityContactStore::getInstance();
     foreach ($store->popContacts() as $contact_id) {
-      CRM_Segmentation_Logic::addSegmentForActivityContact($objectId, $contact_id);
+      if (!empty($objectId) && !empty($contact_id)) {
+        CRM_Segmentation_Logic::addSegmentForActivityContact($objectId, $contact_id);
+      }
     }
   }
 }


### PR DESCRIPTION
It seems there are code paths where this is not the case. We'll skip segmentation processing for those activities.