### PR TITLE
GP-1940: Add exclusion activity, minor export fix

### DIFF
--- a/CRM/Segmentation/ExportJob.php
+++ b/CRM/Segmentation/ExportJob.php
@@ -53,13 +53,17 @@ class CRM_Segmentation_ExportJob {
     }
 
     $exporter->resumeTmpFile($this->tmp_file);
-    $exporter->generateFile(
+    $numExported = $exporter->generateFile(
       $this->campaign_id,
       $this->params,
       $this->offset,
       $this->count,
       $this->is_last,
       TRUE);
+
+    if ($numExported == 0) {
+      return FALSE;
+    }
 
     // update filename
     $filename_handle = fopen($this->tmp_file . '_filename', 'w');
@@ -122,7 +126,7 @@ class CRM_Segmentation_ExportJob {
 
     // create a runner and launch it
     $runner = new CRM_Queue_Runner(array(
-      'title'     => ts("Exportig Campaign '%1'", array(1 => $campaign['title'], 'domain' => 'org.project60.sepa')),
+      'title'     => ts("Exporting Campaign '%1'", array(1 => $campaign['title'], 'domain' => 'de.systopia.segmentation')),
       'queue'     => $queue,
       'errorMode' => CRM_Queue_Runner::ERROR_ABORT,
       'onEndUrl'  => $download_url,

--- a/CRM/Segmentation/Logic.php
+++ b/CRM/Segmentation/Logic.php
@@ -394,6 +394,27 @@ class CRM_Segmentation_Logic {
   }
 
   /**
+   * Add exclusion segment for a mass activity.
+   *
+   * @param $activity_id int
+   * @param $campaign_id int
+   */
+  public static function addExclusionSegmentForMassActivity($activity_id, $campaign_id) {
+    $query = "INSERT IGNORE INTO civicrm_activity_contact_segmentation (activity_contact_id, segment_id)
+                   (SELECT
+                      civicrm_activity_contact.id,
+                      civicrm_segmentation_exclude.segment_id
+                    FROM civicrm_segmentation_exclude
+                    INNER JOIN civicrm_activity_contact ON civicrm_segmentation_exclude.contact_id=civicrm_activity_contact.contact_id
+                    WHERE activity_id = %0
+                      AND campaign_id = %1)";
+    CRM_Core_DAO::executeQuery($query, [
+      [$activity_id, 'Integer'],
+      [$campaign_id, 'Integer'],
+    ]);
+  }
+
+  /**
    * Add segment to an existing ActivityContact. Skips if a segment is
    * already assigned or if activity hasn't been assigned to contact at all.
    *

--- a/CRM/Segmentation/Page/Start.php
+++ b/CRM/Segmentation/Page/Start.php
@@ -121,6 +121,12 @@ class CRM_Segmentation_Page_Start extends CRM_Core_Page {
         WHERE `campaign_id` = {$campaign_id}
           AND `segment_id`  = {$segment_id}");
 
+      // remove exclusions
+      CRM_Core_DAO::executeQuery("
+        DELETE FROM `civicrm_segmentation_exclude`
+        WHERE `campaign_id` = {$campaign_id}
+          AND `segment_id`  = {$segment_id}");
+
       CRM_Core_DAO::executeQuery("
         DELETE FROM `civicrm_segmentation_order`
         WHERE `campaign_id` = {$campaign_id}

--- a/CRM/Segmentation/Upgrader.php
+++ b/CRM/Segmentation/Upgrader.php
@@ -31,4 +31,11 @@ class CRM_Segmentation_Upgrader extends CRM_Segmentation_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_0930() {
+    $this->ctx->log->info('Updating segmentation schema to 0.9.3');
+    $customData = new CRM_Utils_CustomData('de.systopia.segmentation');
+    $customData->syncOptionGroup(__DIR__ . '/../../resources/activity_type_option_group.json');
+    return TRUE;
+  }
+
 }

--- a/resources/activity_type_option_group.json
+++ b/resources/activity_type_option_group.json
@@ -1,0 +1,12 @@
+{
+  "_lookup": ["name"],
+  "name": "activity_type",
+  "_values": [
+    {
+      "_lookup": ["name"],
+      "_translate": ["label"],
+      "label": "Exclusion Record",
+      "name": "Exclusion Record"
+    }
+  ]
+}

--- a/segmentation.php
+++ b/segmentation.php
@@ -224,6 +224,7 @@ function segmentation_civicrm_enable() {
   require_once 'CRM/Utils/CustomData.php';
   $customData = new CRM_Utils_CustomData('de.systopia.segmentation');
   $customData->syncOptionGroup(__DIR__ . '/resources/segments_option_group.json');
+  $customData->syncOptionGroup(__DIR__ . '/resources/activity_type_option_group.json');
   $customData->syncCustomGroup(__DIR__ . '/resources/segmentation_custom_group.json');
 }
 


### PR DESCRIPTION
To keep track of contacts from exclusion tests, this introduces a new activity type "Exclusion Record". When creating activities for a campaign, an activity of this type is created and assigned to contacts marked for exclusion.

Additionally, deleting segments now causes the contacts to be removed from the exclusion table.

This also includes a minor change to the segmentation export runner, preventing empty (header-only) files from being generated.