### PR TITLE
Fix segmentation contact tab not rendering labels

### DIFF
--- a/js/adjust_segment_tab.js
+++ b/js/adjust_segment_tab.js
@@ -16,27 +16,34 @@ var table_wrapper = cj("#custom-SEGMENT_GROUP_ID-table-wrapper");
 var panel = table_wrapper.parent();
 
 // remove the "Add Segments Record" button
-panel.find("a.button[accesskey='N']")
+panel.find(".action-link")
      .hide();
 
-// blank the 6th column (actions) completely
-panel.find("td:nth-child(6)").html('');
+var observer = new MutationObserver(function() {
+  // blank the 6th column (actions) completely
+  panel.find("td:nth-child(6)").html('');
 
-// replace segment / campaign / membership labels
-panel.find("td[class^='crmf-custom_" + segments_field_id + "']").each(function() {
-  cj(this).html(segments_details[cj(this).html()]);
+  // replace segment / campaign / membership labels
+  panel.find("td[class^='crmf-custom_" + segments_field_id + "']")
+    .each(function () {
+      cj(this).html(segments_details[cj(this).html()]);
+    });
+
+  panel.find("td[class^='crmf-custom_" + campaign_field_id + "']")
+    .each(function () {
+      if (campaign_status[cj(this).html()] == '1') {
+        cj(this).closest("tr").addClass("segmentation-planned");
+      }
+      cj(this).html(campaign_details[cj(this).html()]);
+    });
+
+  panel.find("td[class^='crmf-custom_" + membership_field_id + "']")
+    .each(function () {
+      cj(this).html(membership_details[cj(this).html()]);
+    });
 });
 
-panel.find("td[class^='crmf-custom_" + campaign_field_id + "']").each(function() {
-  if (campaign_status[cj(this).html()] == '1') {
-    cj(this).closest("tr").addClass("segmentation-planned");
-  }
-  cj(this).html(campaign_details[cj(this).html()]);
-});
-
-panel.find("td[class^='crmf-custom_" + membership_field_id + "']").each(function() {
-  cj(this).html(membership_details[cj(this).html()]);
-});
+observer.observe(table_wrapper.find('table')[0], { childList: true, subtree: true });
 
 // sort table by first column (date)
 var dt_hooked = false;


### PR DESCRIPTION
This fixes an issue that's causing the "Segmentation" tab in CiviContact to not render labels for campaigns, segments and memberships. This is due to a change in core where data tables are loaded via AJAX. The JS that should render the labels executes before the table is actually rendered, so it's not doing anything.

There's a bit of a performance penalty for this fix (the observer callback is called once for each row in the table), but that should be acceptable with typical pagination limits.