### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/systopia/de.systopia.segmentation/issues</url>
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>1.1-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments/>
   <civix>

--- a/templates/CRM/Segmentation/Form/Split.tpl
+++ b/templates/CRM/Segmentation/Form/Split.tpl
@@ -191,7 +191,7 @@
           {/section}
         </table>
         <div class="crm-segmentation-add-new-segment-wrap">
-          <a title="{ts}Add new segment{/ts}" class="crm-segmentation-add-new-segment button">
+          <a title="{ts escape='htmlattribute'}Add new segment{/ts}" class="crm-segmentation-add-new-segment button">
             <span>
               <i class="crm-i fa-plus-circle"></i>
               {ts}Add new segment{/ts}

--- a/templates/CRM/Segmentation/Page/Start.tpl
+++ b/templates/CRM/Segmentation/Page/Start.tpl
@@ -56,10 +56,10 @@
           <a class="crm-weight-arrow" href="{crmURL p='civicrm/segmentation/start' q="cid=$campaign_id&bottom=`$segment.segment_id`"}"><img src="{$config->resourceBase}i/arrow/last.gif" title="Move to bottom" alt="Move to bottom" class="order-icon"></a>
       </td>
       <td>
-        <a name="contact_list" href="{crmURL p='civicrm/segmentation/contacts' q="snippet=1&cid=$campaign_id&sid=`$segment.segment_id`"}" alt="{ts}View in Popup{/ts}" title="{ts}Show contact list in popup window{/ts}" class="crm-hover-button">
+        <a name="contact_list" href="{crmURL p='civicrm/segmentation/contacts' q="snippet=1&cid=$campaign_id&sid=`$segment.segment_id`"}" alt="{ts escape='htmlattribute'}View in Popup{/ts}" title="{ts escape='htmlattribute'}Show contact list in popup window{/ts}" class="crm-hover-button">
           <div>{ts}Contact List{/ts}</div>
         </a>
-        <a href="{crmURL p='civicrm/segmentation/start' q="cid=$campaign_id&delete=`$segment.segment_id`"}" alt="{ts}Delete Segment{/ts}" title="{ts}Delete the entire segment{/ts}" class="crm-hover-button">
+        <a href="{crmURL p='civicrm/segmentation/start' q="cid=$campaign_id&delete=`$segment.segment_id`"}" alt="{ts escape='htmlattribute'}Delete Segment{/ts}" title="{ts escape='htmlattribute'}Delete the entire segment{/ts}" class="crm-hover-button">
           <div>{ts}Delete Segment{/ts}</div>
         </a>
         <a {if $segment.exclude neq 1 && $segment.count > 0 && $segment.excluded_count == 0}{else}style="display: none;"{/if}


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.